### PR TITLE
Update rank requirements for commands

### DIFF
--- a/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/command/CommandAnnotationScanner.kt
+++ b/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/command/CommandAnnotationScanner.kt
@@ -161,9 +161,9 @@ class CommandAnnotationScanner(private val plugin: MindustryPlugin, private val 
                 )
         }
 
-        if (annotation.rank != Rank.OWNER) {
+        if (annotation.rank != Rank.OWNER || annotation.rank != Rank.HEAD_ADMIN) {
             permission =
-                Permission.anyOf(permission, Permission.permission("imperium.rank.${Rank.HEAD_ADMIN.name.lowercase()}"))
+                Permission.anyOf(permission, Permission.permission("imperium.rank.${Rank.ADMIN.name.lowercase()}"))
         }
 
         return permission

--- a/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/security/VoteKickCommand.kt
+++ b/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/security/VoteKickCommand.kt
@@ -128,12 +128,13 @@ class VoteKickCommand(instances: InstanceManager) :
         onPlayerVote(sender.player, getSession(sender.player.team()), Vote.NO)
     }
 
-    @ImperiumCommand(["vote", "c"], Rank.MODERATOR)
+    @ImperiumCommand(["vote", "c"], Rank.OVERSEER)
     @ClientSide
     fun onVoteCancelCommand(sender: CommandSender, team: Team? = null) {
         onPlayerCancel(sender.player, getSession(team ?: sender.player.team()))
     }
 
+    // TODO: Translate these, important
     @ImperiumCommand(["votekick"])
     @ClientSide
     fun onVotekickCommand(sender: CommandSender, target: Player? = null, @Greedy reason: String? = null) {

--- a/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/world/ExcavateCommand.kt
+++ b/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/world/ExcavateCommand.kt
@@ -125,15 +125,6 @@ class ExcavateCommand(instances: InstanceManager) :
         event.player.sendMessage("You set the $adjective point to (${point.x}, ${point.y})")
     }
 
-    @ImperiumCommand(["excavate|e", "select|s"])
-    @Scope(MindustryGamemode.SURVIVAL, MindustryGamemode.ATTACK, MindustryGamemode.SURVIVAL_EXPERT)
-    @ClientSide
-    private fun onOldExcavateStartCommand(sender: CommandSender) {
-        sender.player.sendMessage(
-            "This command has been changed to just '[accent]/excavate[]' or '[accent]/e[]', use those instead."
-        )
-    }
-
     @ImperiumCommand(["excavate|e"])
     @Scope(MindustryGamemode.SURVIVAL, MindustryGamemode.ATTACK, MindustryGamemode.SURVIVAL_EXPERT)
     @ClientSide
@@ -204,14 +195,14 @@ class ExcavateCommand(instances: InstanceManager) :
         onPlayerVote(sender.player, manager.session, Vote.NO)
     }
 
-    @ImperiumCommand(["excavate|e", "cancel|c"], Rank.MODERATOR)
+    @ImperiumCommand(["excavate|e", "cancel|c"], Rank.OVERSEER)
     @Scope(MindustryGamemode.SURVIVAL, MindustryGamemode.ATTACK, MindustryGamemode.SURVIVAL_EXPERT)
     @ClientSide
     fun onExcavateCancelCommand(sender: CommandSender) {
         onPlayerCancel(sender.player, manager.session)
     }
 
-    @ImperiumCommand(["excavate|e", "force|f"], Rank.MODERATOR)
+    @ImperiumCommand(["excavate|e", "force|f"], Rank.OVERSEER)
     @Scope(MindustryGamemode.SURVIVAL, MindustryGamemode.ATTACK, MindustryGamemode.SURVIVAL_EXPERT)
     @ClientSide
     fun onRtvForceCommand(sender: CommandSender) {

--- a/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/world/KillAllCommand.kt
+++ b/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/world/KillAllCommand.kt
@@ -69,15 +69,14 @@ class KillAllCommand(instances: InstanceManager) :
         onPlayerVote(sender.player, manager.session, Vote.NO)
     }
 
-    @ImperiumCommand(["killall|ku", "c"], Rank.MODERATOR)
+    @ImperiumCommand(["killall|ku", "cancel|c"], Rank.OVERSEER)
     @Scope(MindustryGamemode.SANDBOX)
     @ClientSide
     fun onKillAllUnitsCancelCommand(sender: CommandSender) {
         onPlayerCancel(sender.player, manager.session)
     }
 
-    // TODO: This should have a better name instead of "force"
-    @ImperiumCommand(["killall|ku", "force|f"], Rank.MODERATOR)
+    @ImperiumCommand(["killall|ku", "force|f"], Rank.OVERSEER)
     @ClientSide
     fun onKillAllUnitsTeamCommand(
         sender: CommandSender,

--- a/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/world/RockTheVoteCommand.kt
+++ b/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/world/RockTheVoteCommand.kt
@@ -156,13 +156,13 @@ class RockTheVoteCommand(instances: InstanceManager) :
         onPlayerVote(sender.player, manager.session, Vote.NO)
     }
 
-    @ImperiumCommand(["rtv", "cancel|c"], Rank.MODERATOR)
+    @ImperiumCommand(["rtv", "cancel|c"], Rank.OVERSEER)
     @ClientSide
     fun onRtvCancelCommand(sender: CommandSender) {
         onPlayerCancel(sender.player, manager.session)
     }
 
-    @ImperiumCommand(["rtv", "force|f"], Rank.MODERATOR)
+    @ImperiumCommand(["rtv", "force|f"], Rank.OVERSEER)
     @ClientSide
     fun onRtvForceCommand(sender: CommandSender) {
         onPlayerForceSuccess(sender.player, manager.session)

--- a/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/world/WaveCommand.kt
+++ b/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/world/WaveCommand.kt
@@ -96,7 +96,7 @@ class WaveCommand(instances: InstanceManager) :
         onPlayerVote(sender.player, manager.session, Vote.NO)
     }
 
-    @ImperiumCommand(["ws", "cancel|c"], Rank.MODERATOR)
+    @ImperiumCommand(["ws", "cancel|c"], Rank.OVERSEER)
     @ClientSide
     fun onWaveSkipCancelCommand(sender: CommandSender) {
         onPlayerCancel(sender.player, manager.session)


### PR DESCRIPTION
Changed (hopefully) all rank requirements for forcing/cancelling a vote to be overseer.
Removed a deprecated command from excavate
Changed rank processor to re-allow admins access to all commands regardless of server