### PR TITLE
=/

### DIFF
--- a/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/formation/FormationListener.kt
+++ b/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/formation/FormationListener.kt
@@ -64,14 +64,13 @@ class FormationListener(instances: InstanceManager) : ImperiumApplication.Listen
             val (id, context) = iterator.next()
 
             val player = Groups.player.getByID(id)
-            val playerUnit = player.unit() ?: continue // Player has no unit, skip
-
             if (player == null) {
                 context.deleted = true
                 iterator.remove()
                 continue
             }
-
+            
+            val playerUnit = player.unit() ?: continue // Player has no unit, skip
             if (context.leader != playerUnit) {
                 context.leader = playerUnit
             }


### PR DESCRIPTION
Fixs: ```
An error occurred while handling a Trigger event.: java.lang.RuntimeException: Unable to invoke public final void com.xpdustry.imperium.mindustry.formation.FormationListener.onFormationUpdate() on com.xpdustry.imperium.mindustry.formation.FormationListener@96511ad
    at com.xpdustry.distributor.api.annotation.TriggerHandlerProcessor$TriggerMethodEventHandler.run(TriggerHandlerProcessor.java:66)
    at com.xpdustry.distributor.common.event.EventBusImpl.lambda$subscribe$1(EventBusImpl.java:63)
    at com.xpdustry.distributor.common.event.EventBusImpl$ConsumerCons.get(EventBusImpl.java:100)
    at arc.Events.fire(Events.java:36)
    at mindustry.core.Logic.update(Logic.java:427)
    at arc.backend.headless.HeadlessApplication.mainLoop(HeadlessApplication.java:87)
    at arc.backend.headless.HeadlessApplication$1.run(HeadlessApplication.java:52)
Caused by: java.lang.reflect.InvocationTargetException
    at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:115)
    at java.base/java.lang.reflect.Method.invoke(Method.java:580)
    at com.xpdustry.distributor.api.annotation.TriggerHandlerProcessor$TriggerMethodEventHandler.run(TriggerHandlerProcessor.java:64)
    ... 6 more
Caused by: java.lang.NullPointerException
```