### PR TITLE
Batch world edit tile network updates

### DIFF
--- a/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/misc/TileBulkUpdate.kt
+++ b/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/misc/TileBulkUpdate.kt
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-only
+package com.xpdustry.imperium.mindustry.misc
+
+import mindustry.content.Blocks
+import mindustry.game.Team
+import mindustry.gen.Call
+import mindustry.world.Block
+import mindustry.world.Tile
+import mindustry.world.blocks.environment.OverlayFloor
+
+fun Iterable<Tile>.setBlocksNet(block: Block, team: Team = Team.derelict, rotation: Int = 0) {
+    val tiles = toList()
+    if (tiles.isEmpty()) return
+
+    if (block == Blocks.air || !block.rotate || rotation == 0) {
+        Call.setTileBlocks(block, team, tiles.packedPositions())
+    } else {
+        tiles.forEach { Call.setTile(it, block, team, rotation) }
+    }
+}
+
+fun Iterable<Tile>.setFloorsNet(floor: Block) {
+    val positions = packedPositions()
+    if (positions.isNotEmpty()) {
+        Call.setTileFloors(floor, positions)
+    }
+}
+
+fun Iterable<Tile>.setOverlaysNet(overlay: Block) {
+    val tiles = toList()
+    if (tiles.isEmpty()) return
+
+    if (overlay is OverlayFloor) {
+        Call.setTileOverlays(overlay, tiles.packedPositions())
+    } else {
+        tiles.forEach { Call.setOverlay(it, overlay) }
+    }
+}
+
+private fun Iterable<Tile>.packedPositions(): IntArray = map(Tile::pos).toIntArray()

--- a/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/world/ExcavateCommand.kt
+++ b/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/world/ExcavateCommand.kt
@@ -23,6 +23,8 @@ import com.xpdustry.imperium.mindustry.misc.Entities
 import com.xpdustry.imperium.mindustry.misc.ImmutablePoint
 import com.xpdustry.imperium.mindustry.misc.PlayerMap
 import com.xpdustry.imperium.mindustry.misc.runMindustryThread
+import com.xpdustry.imperium.mindustry.misc.setBlocksNet
+import com.xpdustry.imperium.mindustry.misc.setOverlaysNet
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.abs
 import kotlin.math.max
@@ -227,14 +229,17 @@ class ExcavateCommand(instances: InstanceManager) :
         for (y in area.y1..area.y2) {
             delay(100.milliseconds)
             runMindustryThread {
+                val tiles = mutableListOf<mindustry.world.Tile>()
+                val overlays = mutableListOf<mindustry.world.Tile>()
                 for (x in area.x1..area.x2) {
                     val tile = Vars.world.tile(x, y)
                     if (!(tile.block()?.isStatic == true || tile.block() is TreeBlock)) {
                         continue
                     }
-                    val floor = tile.floor()
-                    Call.setTile(tile, Blocks.air, Team.derelict, 0)
-                    Call.setFloor(tile, floor, Blocks.air)
+                    tiles += tile
+                    if (tile.overlay() != Blocks.air) {
+                        overlays += tile
+                    }
                     Call.effect(
                         Fx.flakExplosion,
                         x.toFloat() * Vars.tilesize,
@@ -243,6 +248,8 @@ class ExcavateCommand(instances: InstanceManager) :
                         Color.white,
                     )
                 }
+                tiles.setBlocksNet(Blocks.air, Team.derelict)
+                overlays.setOverlaysNet(Blocks.air)
                 val cx = area.x1 + ((area.x2 - area.x1) / 2F) * Vars.tilesize
                 Call.soundAt(Sounds.blockPlace1, cx, y.toFloat() * Vars.tilesize, 1F, getNextPitch(sequence))
             }

--- a/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/world/WorldEditCommand.kt
+++ b/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/world/WorldEditCommand.kt
@@ -11,6 +11,9 @@ import com.xpdustry.imperium.mindustry.command.annotation.ClientSide
 import com.xpdustry.imperium.mindustry.command.annotation.Flag
 import com.xpdustry.imperium.mindustry.misc.Rotation
 import com.xpdustry.imperium.mindustry.misc.reloadWorldData
+import com.xpdustry.imperium.mindustry.misc.setBlocksNet
+import com.xpdustry.imperium.mindustry.misc.setFloorsNet
+import com.xpdustry.imperium.mindustry.misc.setOverlaysNet
 import mindustry.Vars
 import mindustry.content.Blocks
 import mindustry.game.Team
@@ -70,19 +73,25 @@ class WorldEditCommand : ImperiumApplication.Listener {
             return
         }
 
+        val floorTiles = mutableListOf<mindustry.world.Tile>()
+        val overlayTiles = mutableListOf<mindustry.world.Tile>()
+        val blockTiles = mutableListOf<mindustry.world.Tile>()
         repeat(w) { ox ->
             repeat(h) { oy ->
                 if (ox % size == 0 && oy % size == 0) {
                     val tile = Vars.world.tile(x + ox, y + oy)
-                    floor?.let { tile.setFloorNet(it.asFloor()) }
-                    overlay?.let { tile.setOverlayNet(it.asFloor()) }
+                    floor?.let { floorTiles += tile }
+                    overlay?.let { overlayTiles += tile }
                     if (block != null && (override || tile.getLinkedTilesAs(block, Seq()).all { it.build == null })) {
-                        tile.setNet(Blocks.air)
-                        tile.setNet(block, team, rotation.ordinal)
+                        blockTiles += tile
                     }
                 }
             }
         }
+
+        floor?.let { floorTiles.setFloorsNet(it) }
+        overlay?.let { overlayTiles.setOverlaysNet(it) }
+        block?.let { blockTiles.setBlocksNet(it, team, rotation.ordinal) }
 
         // Reindex the spawn blocks
         if (overlay == Blocks.spawn) {


### PR DESCRIPTION
## Summary
- Added `TileBulkUpdate` helpers to batch floor, overlay, and block network updates across multiple tiles.
- Updated `WorldEditCommand` to collect tiles first and send batched floor/overlay/block changes instead of per-tile calls.
- Updated `ExcavateCommand` to batch block removal and overlay clearing per row while preserving the existing effects and sounds.
- Reduces network chatter and should make large world edits less expensive.

## Testing
- Not run (not requested).
- Verified the changes are limited to the world edit and excavation paths plus the new shared bulk-update helper.