### PR TITLE
Respect fog mode in day-night cycle updates

### DIFF
--- a/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/game/DayNightCycleListener.kt
+++ b/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/game/DayNightCycleListener.kt
@@ -19,7 +19,7 @@ class DayNightCycleListener(instances: InstanceManager) : ImperiumApplication.Li
 
     @EventHandler
     fun onMenuToPlayEvent(event: MenuToPlayEvent) {
-        if (!Vars.state.rules.lighting) {
+        if (!Vars.state.rules.fog && !Vars.state.rules.lighting) {
             Vars.state.map.dayNightCycle = true
             Vars.state.rules.lighting = true
         }
@@ -27,7 +27,8 @@ class DayNightCycleListener(instances: InstanceManager) : ImperiumApplication.Li
 
     @TaskHandler(interval = 1, unit = MindustryTimeUnit.SECONDS)
     fun onSolarCycleUpdate() {
-        if (!Vars.state.isGame || !Vars.state.rules.lighting || !Vars.state.map.dayNightCycle) return
+        if (!Vars.state.isGame || Vars.state.rules.fog || !Vars.state.rules.lighting || !Vars.state.map.dayNightCycle)
+            return
         val time = ((System.currentTimeMillis() / 1000L) % cycle) / (cycle * 0.5F)
         Vars.state.rules.ambientLight.a = Interp.sine.apply(0F, 0.8F, time)
         Call.setRules(Vars.state.rules)


### PR DESCRIPTION
## Summary
- Avoids enabling the day-night cycle when fog mode is active.
- Skips solar cycle ambient light updates while fog is enabled.
- Keeps the existing lighting behavior unchanged when fog is off.

## Testing
- Not run (PR content only).
- Confirmed the change is limited to `DayNightCycleListener.kt`.
- Reviewed the updated guards for both menu-to-play and periodic solar cycle updates.