### PR TITLE
Only set the relevant rule

### DIFF
--- a/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/game/DayNightCycleListener.kt
+++ b/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/game/DayNightCycleListener.kt
@@ -31,6 +31,6 @@ class DayNightCycleListener(instances: InstanceManager) : ImperiumApplication.Li
             return
         val time = ((System.currentTimeMillis() / 1000L) % cycle) / (cycle * 0.5F)
         Vars.state.rules.ambientLight.a = Interp.sine.apply(0F, 0.8F, time)
-        Call.setRules(Vars.state.rules)
+        Call.setRule("ambientLight", Vars.state.rules.ambientLight)
     }
 }

--- a/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/game/DayNightCycleListener.kt
+++ b/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/game/DayNightCycleListener.kt
@@ -12,6 +12,7 @@ import com.xpdustry.imperium.common.inject.get
 import com.xpdustry.imperium.mindustry.misc.dayNightCycle
 import mindustry.Vars
 import mindustry.gen.Call
+import mindustry.io.JsonIO
 
 class DayNightCycleListener(instances: InstanceManager) : ImperiumApplication.Listener {
 
@@ -31,6 +32,6 @@ class DayNightCycleListener(instances: InstanceManager) : ImperiumApplication.Li
             return
         val time = ((System.currentTimeMillis() / 1000L) % cycle) / (cycle * 0.5F)
         Vars.state.rules.ambientLight.a = Interp.sine.apply(0F, 0.8F, time)
-        Call.setRule("ambientLight", Vars.state.rules.ambientLight)
+        Call.setRule("ambientLight", JsonIO.write(Vars.state.rules.ambientLight))
     }
 }


### PR DESCRIPTION
Only sets the relevant rule, saves network bandwidth not having to send the entire rules package and stops it from reseting clientside rule modifications (i use them) that arent ambientLight modifications