### PR TITLE
fix announcing derelict source deletions on other player teams

### DIFF
--- a/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/game/AlertListener.kt
+++ b/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/game/AlertListener.kt
@@ -3,6 +3,7 @@ package com.xpdustry.imperium.mindustry.game
 
 import arc.func.Cons
 import arc.math.geom.Point2
+import arc.struct.IntMap
 import arc.struct.IntSet
 import com.xpdustry.distributor.api.Distributor
 import com.xpdustry.distributor.api.annotation.EventHandler
@@ -20,6 +21,7 @@ import com.xpdustry.imperium.mindustry.translation.announcement_important_block_
 import com.xpdustry.imperium.mindustry.translation.announcement_important_block_destroyed
 import mindustry.Vars
 import mindustry.game.EventType
+import mindustry.game.Team
 import mindustry.net.Administration.ActionType
 import mindustry.world.blocks.ConstructBlock
 import mindustry.world.blocks.ConstructBlock.ConstructBuild
@@ -35,6 +37,7 @@ class AlertListener constructor(private val config: ImperiumConfig) : ImperiumAp
     private val explosives = MindustryCollections.immutableList(Vars.content.items()).filter { it.explosiveness > 0 }
     private val generators = IntSet()
     private val generatorsRateLimiter = SimpleRateLimiter<Int>(1, config.mindustry.world.explosiveDamageAlertDelay)
+    private val preChangeTeams = IntMap<Team>()
 
     override fun onImperiumInit() {
         Vars.netServer.admins.addActionFilter {
@@ -72,12 +75,20 @@ class AlertListener constructor(private val config: ImperiumConfig) : ImperiumAp
     }
 
     @EventHandler
+    fun onSourceBlockPreChange(event: EventType.TilePreChangeEvent) {
+        if (event.tile.block().isSourceBlock) {
+            preChangeTeams.put(event.tile.pos(), event.tile.team())
+        }
+    }
+
+    @EventHandler
     fun onExplosiveGeneratorChange(event: EventType.TileChangeEvent) {
         if (event.tile.block() is ConsumeGenerator) generators.add(event.tile.pos())
     }
 
     @TriggerHandler(EventType.Trigger.update)
     fun onExplosiveGeneratorCheck() {
+        preChangeTeams.clear() // just using the update trigger
         if (
             (!Vars.state.rules.reactorExplosions ||
                 (Vars.state.rules.infiniteResources && !Vars.state.rules.damageExplosions))
@@ -129,9 +140,10 @@ class AlertListener constructor(private val config: ImperiumConfig) : ImperiumAp
         if (Vars.state.rules.infiniteResources) return
         val building = event.tile.build
         if (event.breaking && building is ConstructBuild && building.current.isSourceBlock) {
+            val originalTeam = preChangeTeams.get(event.tile.pos()) ?: building.team()
             Distributor.get()
                 .audienceProvider
-                .getTeam(building.team())
+                .getTeam(originalTeam)
                 .sendMessage(
                     announcement_important_block_destroyed(building.current, event.tile.x.toInt(), event.tile.y.toInt())
                 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source-block destruction alerts to display the correct team associated with the block before it was changed or destroyed.
  * Added a fallback to the current team when previous team information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix derelict source block destruction alerts sending to wrong player team
> When a source block is destroyed, the alert was sent to the block's current team, which could be wrong if the block had changed teams (e.g. derelict blocks). The fix captures the block's team at `TilePreChangeEvent` time in a `preChangeTeams` map, then uses that stored team when sending the destruction announcement. The map is cleared each update tick to avoid stale entries.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd10484.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->