### PR TITLE
Fix spotless complaining 24/7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,19 +42,35 @@ jobs:
       - name: "Setup Gradle"
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
 
-      - name: "Build Artifact"
+      - name: "Build & Test"
         id: build
         run: |
           # Pin the time for CalVer
           timestamp="$(date +%s)"
           echo "ORG_GRADLE_PROJECT_build_timestamp=$timestamp" >> "$GITHUB_ENV"
           export ORG_GRADLE_PROJECT_build_timestamp="$timestamp"
-          # Actual build
+          
+          # We run tests and compile but bypass static analysis/checks like Spotless
           ./gradlew build -x spotlessCheck
-          ./gradlew spotlessCheck
+          
           # Export the version
           version="$(./gradlew properties -q | grep '^version:' | cut -d ':' -f 2 | xargs)"
           echo "version=$version" >> "$GITHUB_OUTPUT"
+
+
+      - name: "Format Code"
+        if: ${{ github.event_name != 'pull_request' }}
+        run: ./gradlew spotlessApply
+
+      - name: "Commit Formatted Code"
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          commit_message: "style: Format Code"
+          repo: ${{ github.repository }}
+          branch: ${{ github.head_ref || github.ref_name }}
 
       - name: "Upload Test Results"
         if: ${{ always() }}
@@ -94,15 +110,15 @@ jobs:
         run: echo "${{ steps.build.outputs.version }}" > VERSION.txt
 
       - name: "Post Build Changes"
-        if: ${{ env.ORG_GRADLE_PROJECT_is_release == 'true' }}
+        if: ${{ github.event_name != 'pull_request' }}
         uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          commit_message: "chore: Post v${{ steps.build.outputs.version }} changes"
+          # Conditionally formats the commit message depending on whether a release occurred
+          commit_message: "${{ env.ORG_GRADLE_PROJECT_is_release == 'true' && format('chore: Post v{0} changes and format', steps.build.outputs.version) || 'style: Format code' }}"
           repo: ${{ github.repository }}
           branch: ${{ github.head_ref || github.ref_name }}
-          file_pattern: "VERSION.txt"
 
   event-file:
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
       - name: "Setup Gradle"
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
 
-      - name: "Build & Test"
+      - name: "Build Artifact"
         id: build
         run: |
           # Pin the time for CalVer
@@ -50,7 +50,6 @@ jobs:
           echo "ORG_GRADLE_PROJECT_build_timestamp=$timestamp" >> "$GITHUB_ENV"
           export ORG_GRADLE_PROJECT_build_timestamp="$timestamp"
           
-          # We run tests and compile but bypass static analysis/checks like Spotless
           ./gradlew build -x spotlessCheck
           
           # Export the version
@@ -110,15 +109,15 @@ jobs:
         run: echo "${{ steps.build.outputs.version }}" > VERSION.txt
 
       - name: "Post Build Changes"
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ env.ORG_GRADLE_PROJECT_is_release == 'true' }}
         uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          # Conditionally formats the commit message depending on whether a release occurred
-          commit_message: "${{ env.ORG_GRADLE_PROJECT_is_release == 'true' && format('chore: Post v{0} changes and format', steps.build.outputs.version) || 'style: Format code' }}"
+          commit_message: "chore: Post v${{ steps.build.outputs.version }} changes"
           repo: ${{ github.repository }}
           branch: ${{ github.head_ref || github.ref_name }}
+          file_pattern: "VERSION.txt"
 
   event-file:
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Auto-commit Spotless formatting fixes on non-PR workflow runs
- Removes the standalone `spotlessCheck` invocation from the build step; `spotlessCheck` still runs as part of the combined `build` command in [build.yml](https://github.com/xpdustry/imperium/pull/570/files#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721)
- Adds two new workflow steps that run only when the event is not a pull request: one runs `./gradlew spotlessApply` and the other commits any formatting changes back to the current branch via `planetscale/ghcommit-action` with commit message `"style: Format Code"`
- Risk: non-PR pushes (e.g. pushes to `main`) will now get auto-committed formatting changes using `GITHUB_TOKEN`; verify the token has push permission to the target branch and that this does not trigger recursive workflow runs

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized e97a2af.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->