### PR TITLE
Make hound more lenient during startup

### DIFF
--- a/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/monitoring/BlockHoundService.kt
+++ b/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/monitoring/BlockHoundService.kt
@@ -13,6 +13,7 @@ import com.xpdustry.imperium.mindustry.misc.runMindustryThread
 import java.io.ByteArrayInputStream
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 import kotlinx.coroutines.CoroutineScope
@@ -22,7 +23,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import okhttp3.MediaType.Companion.toMediaType
-import kotlin.time.Duration.Companion.minutes
 
 @Inject
 class BlockHoundService(
@@ -39,7 +39,10 @@ class BlockHoundService(
         val startup = startTime + 1.minutes
         job = scope.launch {
             while (isActive) {
-                val timeoutTime = if(Clock.System.now() < startup) { 1.minutes } else 10.seconds
+                val timeoutTime =
+                    if (Clock.System.now() < startup) {
+                        1.minutes
+                    } else 10.seconds
                 val blocked =
                     runCatching { runMindustryThread(timeoutTime) { /* Nothin' */ } }
                         .fold(

--- a/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/monitoring/BlockHoundService.kt
+++ b/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/monitoring/BlockHoundService.kt
@@ -13,7 +13,6 @@ import com.xpdustry.imperium.mindustry.misc.runMindustryThread
 import java.io.ByteArrayInputStream
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.hours
-import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 import kotlinx.coroutines.CoroutineScope
@@ -41,7 +40,7 @@ class BlockHoundService(
             while (isActive) {
                 val timeoutTime =
                     if (Clock.System.now() < startup) {
-                        1.minutes
+                        30.seconds
                     } else 10.seconds
                 val blocked =
                     runCatching { runMindustryThread(timeoutTime) { /* Nothin' */ } }

--- a/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/monitoring/BlockHoundService.kt
+++ b/imperium-mindustry/src/main/kotlin/com/xpdustry/imperium/mindustry/monitoring/BlockHoundService.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import okhttp3.MediaType.Companion.toMediaType
+import kotlin.time.Duration.Companion.minutes
 
 @Inject
 class BlockHoundService(
@@ -34,10 +35,13 @@ class BlockHoundService(
     private var lastWarn: Instant? = null
 
     init {
+        val startTime = Clock.System.now()
+        val startup = startTime + 1.minutes
         job = scope.launch {
             while (isActive) {
+                val timeoutTime = if(Clock.System.now() < startup) { 1.minutes } else 10.seconds
                 val blocked =
-                    runCatching { runMindustryThread(timeout = 10.seconds) { /* Nothin' */ } }
+                    runCatching { runMindustryThread(timeoutTime) { /* Nothin' */ } }
                         .fold(
                             onSuccess = { false },
                             onFailure = { error ->


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add startup grace window to `BlockHoundService` Mindustry thread check
Captures the service init time and uses a 30-second timeout for the Mindustry thread check during the first minute after startup, then switches to the normal 10-second timeout. This gives the server more headroom while it warms up. Risk: the 30-second window in [BlockHoundService.kt](https://github.com/xpdustry/imperium/pull/571/files#diff-3489a4a0905da665bb125b7b14e81ccd0f0100fa7d849ec1dab0dcbc3ee67f21) could mask real startup deadlocks for up to one minute.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1afe41b.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->